### PR TITLE
Updates GET /profile Endpoint

### DIFF
--- a/Public/openapi.yml
+++ b/Public/openapi.yml
@@ -52,6 +52,21 @@ paths:
         - Profile
       security:
         - profileAuth: []
+      parameters:
+        - in: query
+          name: include_plots
+          schema:
+            type: boolean
+            default: false
+          required: false
+          description: If the users owned plots should be included in the response.
+        - in: query
+          name: include_inventory
+          schema:
+            type: boolean
+            default: false
+          required: false
+          description: If the users inventory should be included in the response.
       
       responses:
         '200':
@@ -613,10 +628,12 @@ components:
           type: integer
           description: The amount of money the profile has.
         plots:
+          nullable: true
           type: array
           items:
             $ref: '#/components/schemas/Plot'
         inventory:
+          nullable: true
           $ref: '#/components/schemas/Inventory'
 
     Plot:

--- a/Sources/App/Controllers/ProfileController.swift
+++ b/Sources/App/Controllers/ProfileController.swift
@@ -37,9 +37,13 @@ class ProfileController: RouteCollection {
     }
     
     private func getProfile(_ req: Request) async throws -> Profile {
-        try await req.getProfile { query in
-            query.with(\.$plots)
-                .with(\.$inventory)
+        let includePlots = (try? req.query.get(Bool.self, at: "include_plots")) ?? false
+        let includeInventory = (try? req.query.get(Bool.self, at: "include_inventory")) ?? false
+        
+        return try await req.getProfile { query in
+            query
+                .with(\.$plots, when: includePlots)
+                .with(\.$inventory, when: includeInventory)
         }
     }
     
@@ -68,3 +72,5 @@ class ProfileController: RouteCollection {
         }
     }
 }
+
+

--- a/Sources/App/Extensions/QueryBuilder+ConditionallyWith.swift
+++ b/Sources/App/Extensions/QueryBuilder+ConditionallyWith.swift
@@ -1,0 +1,22 @@
+//
+//  File.swift
+//  
+//
+//  Created by Lukas Simonson on 7/3/24.
+//
+
+import Fluent
+
+extension EagerLoadBuilder {
+    func with<Relation>(
+        _ relationKey: KeyPath<Model, Relation>,
+        when condition: Bool
+    ) -> Self where Relation: EagerLoadable, Relation.From == Model
+    {
+        if condition {
+            Relation.eagerLoad(relationKey, to: self)
+        }
+        
+        return self
+    }
+}

--- a/Sources/App/Models/Profile.swift
+++ b/Sources/App/Models/Profile.swift
@@ -8,7 +8,6 @@
 import Vapor
 import Fluent
 
-
 final class Profile: Model, Content {
     @ID(key: .id)
     var id: UUID?
@@ -46,8 +45,8 @@ extension Profile {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
         try container.encode(balance, forKey: .balance)
-        try container.encode(plots, forKey: .plots)
-        try container.encodeIfPresent(inventory, forKey: .inventory)
+        try container.encodeIfPresent($plots.value, forKey: .plots)
+        try container.encodeIfPresent($inventory.value, forKey: .inventory)
     }
     
     enum CodingKeys: String, CodingKey {


### PR DESCRIPTION
Adds two different query parameters to the GET /profile endpoint. These parameters control what information is included in the response. Now, by default, only the balance and name of the user will be included. You can toggle the inventory and plots information using the 'include_inventory' and 'include_plots' query parameters respectively.